### PR TITLE
Corrigir caminho do 'gatekeep' para importação do security_check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,54 @@ Todas as alterações notáveis neste projeto serão documentadas neste arquivo.
 
 Arquivo gerado automaticamente via `git-cliff`.
 
+## v3.2.28 - 10/01/2026
+
+### ♻️ Refatoração & Melhorias
+
+* Migra SDK do Google AI para `google-genai` v1.0
+
+* Move função para inserir conhecimento na base de dados para um script separado
+
+* Altera SDK do Google AI para `google-genai`
+
+* Melhoria na execução da lógica
+
+* Altera SDK do Google AI para `google-genai`
+
+
+### ✨ Funcionalidades
+
+* Exibe erro detalhado caso o prompt não possa ser respondido
+
+
+### 🐛 Correções
+
+* Corrige erro de chamada de função para salvar versão do git em error_logs
+
+
+### 📚 Documentação
+
+* Atualiza CHANGELOG.md com novas entradas
+
+
+### 📦 Build & Dependências
+
+* Migra gerenciamento de dependencias para uv
+
+
+### 🔧 Tarefas Internas
+
+* Adiciona scripts/debug_models.py ao .gitignore
+
+
+### 🧪 Testes Unitários e de Integração
+
+* Corrige testes de integração
+
+* Testes unitários atualizados para usar lib `google.genai`
+
+* Remove importação que não existe
+
 ## v3.2.27 - 06/01/2026
 
 ### ♻️ Refatoração & Melhorias


### PR DESCRIPTION
## 🔗 Issues Relacionadas
<!-- Cite as issues que este PR resolve. Ex: Fixes #12, Closes #45 -->

## 📝 Descrição das Mudanças
Alterar o caminho de importação do 'gatekeep' para garantir que o módulo 'security_check' seja acessível corretamente.

## ✅ Checklist de Qualidade
Por favor, verifique se você cumpriu os itens abaixo:

- [X] **Executei o script de gatekeep localmente (gatekeep/security_check.py) e ele não encontrou problemas.**
- [X] Testei minhas alterações localmente (o projeto roda sem erros).
- [X] Atualizei a documentação (se necessário).
- [X] Minhas mudanças respeitam o [Código de Conduta](../CODE_OF_CONDUCT.md) e a [Política de Privacidade](../PRIVACY_POLICY.md).
- [X] O código segue boas práticas de segurança (não expõe chaves API, etc).
