### PR TITLE
fix(tests): pular teste de integracao do Gemini na CI se a chave for mockada

### DIFF
--- a/tests/integration/test_gemini_integration.py
+++ b/tests/integration/test_gemini_integration.py
@@ -44,8 +44,8 @@ def test_gemini_connection_and_generation():
     """
     api_key = get_gemini_key()
 
-    if not api_key:
-        pytest.skip("⚠️ Chave do Gemini não encontrada. Pulando teste de integração.")
+    if not api_key or api_key.startswith("mock"):
+        pytest.skip("⚠️ Chave do Gemini real não configurada (está mockada ou vazia). Pulando teste de integração.")
 
     assert len(api_key) > 10, "❌ Chave do Gemini parece inválida ou curta demais."
 


### PR DESCRIPTION
Este Pull Request corrige a falha no pipeline de testes e deploy (`🚀 Production Pipeline`) na branch `main` decorrente da ausência de credenciais de produção reais da API do Gemini no ambiente da CI/CD do GitHub Actions.

### Correções Aplicadas:
- **Resolução de Erro de Quota/Chave Inválida**: O arquivo `tests/integration/test_gemini_integration.py` foi atualizado para verificar se a chave de API é nula ou se está mockada (começando com `"mock"`, que é a chave `"mock-gemini-key"` injetada pelo `conftest.py` global nos ambientes de teste).
- **Tratamento de Skip de Integração**: Caso a chave seja mockada, o teste de integração real é pulado graciosamente (`pytest.skip()`) assim como já ocorria com a conexão ao Supabase, impedindo a falha indevida no pipeline de deploy.

Com isso, a execução do pipeline de testes na branch `main` passará com sucesso (com os 14 testes unitários verdes e os 2 de integração ignorados por falta de chaves), habilitando o deploy correto do aplicativo.
