### PR TITLE
test: pula variaveis de ambiente ficticias em testes de integracao

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,11 +8,16 @@ sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")
 
 
 @pytest.fixture(autouse=True)
-def set_dummy_env_vars():
+def set_dummy_env_vars(request):
     """
     Define variáveis de ambiente fictícias para evitar erros de 'chave faltando'
     antes mesmo de chegar nos mocks de cliente.
+    Não aplica o patch se o teste for de integração real.
     """
+    if "integration" in request.node.keywords or "tests/integration" in str(request.node.fspath):
+        yield
+        return
+
     with patch.dict(
         os.environ,
         {


### PR DESCRIPTION
## 📝 Descrição das Mudanças

Este PR corrige a falha no pipeline de CI causada pelo teste de integração `test_conexao_supabase_real` na branch `main`:

* **Problema:** A fixture `set_dummy_env_vars` (que roda automaticamente em todos os testes) estava aplicando patch nas variáveis de ambiente `SUPABASE_URL` e `SUPABASE_KEY` com valores fictícios (`https://mock.supabase.co`) mesmo para os testes de integração. Como no ambiente de CI não há arquivo `.streamlit/secrets.toml` com credenciais reais, o teste de integração tentava se conectar ao domínio fictício e falhava com um erro de DNS/conexão (`ConnectError`).
* **Solução:** Ajustada a fixture `set_dummy_env_vars` no [conftest.py](file:///home/holmes/dev/projeto-vox/vox-ai/tests/conftest.py) para identificar se o teste em execução pertence à suite de testes de integração (`tests/integration` ou `@pytest.mark.integration`). Se for, a fixture simplesmente pula a injeção dos mocks. Com isso, os testes de integração detectam que não há chaves no CI e são pulados (`SKIPPED`) de forma limpa, permitindo que a build passe com sucesso.

## ✅ Checklist de Qualidade

- [x] Executei o script de gatekeep localmente (`gatekeep/security_check.py`) e ele não encontrou problemas.
- [x] Testei minhas alterações localmente (o projeto roda sem erros).
- [x] Atualizei a documentação (se necessário).
- [x] Minhas mudanças respeitam o Código de Conduta `/CODE_OF_CONDUCT.md` e a Política de Privacidade `/PRIVACY_POLICY.md`.
- [x] O código segue boas práticas de segurança (não expõe chaves API, etc).
